### PR TITLE
Expose type autoDestroy from @rc-component/trigger

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -23,6 +23,7 @@ export interface DropdownProps
     | 'mouseLeaveDelay'
     | 'onPopupAlign'
     | 'builtinPlacements'
+    | 'autoDestroy'
   > {
   minOverlayWidthMatchTrigger?: boolean;
   arrow?: boolean;


### PR DESCRIPTION
Exposed `autoDestroy` prop in `rc-dropdown` from `TriggerProps` as its useful when we need to destroy after dropdown close for custom overlay. Currently for this hack is required and need to extend `TriggerProps` manually with `@rc-component/trigger`